### PR TITLE
Fix theme parse error of "gtkmix"

### DIFF
--- a/src/sass/_colors.scss
+++ b/src/sass/_colors.scss
@@ -7,6 +7,11 @@
   @return unquote("alpha(#{$c}, #{$a})");
 }
 
+@function gtkmix($c1,$c2,$r) {
+  $ratio: 1 -  $r / 100%; // match SCSS mix()
+  @return unquote("mix(#{$c1},#{$c2},#{$ratio})");
+}
+
 @function on($color, $state: 'primary') {
   // Allow 'light' or 'dark' to $color
   @if ($color == 'light') { $color: $white; }


### PR DESCRIPTION
Fix the following problem when opening gnome-text-editor in the terminal.

![image](https://github.com/vinceliuice/Lavanda-gtk-theme/assets/59191277/1b86e104-8974-4f6e-a7b3-c4e78818c327)